### PR TITLE
makeRange fix for negative dataset values

### DIFF
--- a/lib/makeRange.js
+++ b/lib/makeRange.js
@@ -28,7 +28,7 @@ type Range = {
  */
 function makeRange(datasets : Array<Dataset>, totalize: boolean): Range {
   var min = Number.MAX_VALUE;
-  var max = 0;
+  var max = Number.NEGATIVE_INFINITY;
   if (totalize) {
     var dataArray = resolveDatasets(datasets);
     dataArray.forEach(function(data, index) {


### PR DESCRIPTION
Hello and thank you for this library.

makeRange function doesn't work properly when range contains only negative values.
The problem is simple:

```
 var max = 0;

 max = Math.max(max, ...dataset.values);
```

In this situation max value will be 0 even if dataset.values array contain only negative values, and, of course, it is not correct. My commit fixes this problem.
